### PR TITLE
chore(ci): update base path for GitHub Pages deployment

### DIFF
--- a/vite.config.example.js
+++ b/vite.config.example.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: 'example',
+  base: process.env.GITHUB_ACTIONS ? '/cm-theme/' : '/',
   build: {
     outDir: '../demo',
     emptyOutDir: true


### PR DESCRIPTION
### Proposed Changes

In [the current GH Pages deployment](https://bpmn-io.github.io/cm-theme/), it can be observed that the javascript asset is expected at the wrong location. As the GH pages deployment lives at a subfolder with the same name as the repository name, this pull request aims to introduce a `base` path for the `build`s taking place in the GH Actions.

This should enable us to see the demo both in GH Pages and local.

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
