### PR TITLE
Update property name colors

### DIFF
--- a/src/feel-dark.ts
+++ b/src/feel-dark.ts
@@ -12,8 +12,8 @@ export const feelDark = createTheme({
     { tag: t.bool, color: '#f47067' },
     { tag: t.null, color: '#f47067' },
 
-    { tag: t.propertyName, color: '#f69d50' },
-    { tag: t.definition(t.propertyName), color: '#f69d50' },
+    { tag: t.propertyName, color: '#adbac7' },
+    { tag: t.definition(t.propertyName), color: '#adbac7' },
     { tag: t.string, color: '#96d0ff' },
     { tag: t.special(t.string), color: '#96d0ff' },
     { tag: t.number, color: '#6bc46d' },

--- a/src/feel-light.ts
+++ b/src/feel-light.ts
@@ -12,8 +12,8 @@ export const feelLight = createTheme({
     { tag: t.bool, color: '#a31515' },
     { tag: t.null, color: '#a31515' },
 
-    { tag: t.propertyName, color: '#9a6700' },
-    { tag: t.definition(t.propertyName), color: '#9a6700' },
+    { tag: t.propertyName, color: '#24292f' },
+    { tag: t.definition(t.propertyName), color: '#24292f' },
     { tag: t.string, color: '#0a3069' },
     { tag: t.special(t.string), color: '#0a3069' },
     { tag: t.number, color: '#06704a' },


### PR DESCRIPTION
### Proposed Changes

This pull request aims to make the property name colors as discussed and demo-ed [here](https://camunda.slack.com/archives/C0AH8BAJBN2/p1779354629702109?thread_ts=1778617242.408409&cid=C0AH8BAJBN2)/below.

<img width="925" height="472" alt="image" src="https://github.com/user-attachments/assets/8efe314c-ba3d-47b6-8ea4-353232cf87dd" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
